### PR TITLE
Adds Node 6 as a CI target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
 - '0.12'
 - '4'
 - '5'
+- '6'
 cache:
   directories:
   - node_modules


### PR DESCRIPTION
This will build Meyda against node 6 in Travis. Context: Node 6 was released earlier this evening CEST. Fingers crossed.