### PR TITLE
Adds JSFFT 0.0.2 fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "dct": "0.0.3",
     "gulp": "^3.9.0",
-    "jsfft": "git://github.com/dntj/jsfft.git",
+    "jsfft": "^0.0.2",
     "node-getopt": "^0.2.3",
     "through2": "^2.0.1",
     "wav": "^1.0.0"

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,6 @@
 import * as utilities from './utilities';
 import * as extractors from './featureExtractors';
-import * as fft from 'jsfft';
-import * as complexArray from 'jsfft/lib/complex_array';
+import {ComplexArray} from 'jsfft';
 import {MeydaAnalyzer} from './meyda-wa';
 
 var Meyda = {
@@ -139,7 +138,7 @@ var prepareSignalWithSpectrum = function (signal,
     windowingFunction);
 
   // create complexarray to hold the spectrum
-  var data = new complexArray.ComplexArray(bufferSize);
+  var data = new ComplexArray(bufferSize);
 
   // map time domain
   data.map(function (value, i, n) {


### PR DESCRIPTION
Although this fixes JSFFT, it still does not let the buildWeb gulp task complete. Uglify sees ES6 code from jsfft and freaks out - Babelify isn't doing its job :'( 