### PR TITLE
Build web dist as UMD

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -9,13 +9,13 @@ var babelify = require('babelify');
 var webpack = require('webpack-stream');
 
 gulp.task('buildWeb:regular', function() {
-  return gulp.src('./src/main.js')
+  return gulp.src('./src/index.js')
     .pipe(webpack(require('./webpack.config.js').regular, require('webpack'))) // pass webpack for webpack2
     .pipe(gulp.dest('./dist/web'));
 });
 
 gulp.task('buildWeb:minified', function() {
-  return gulp.src('./src/main.js')
+  return gulp.src('./src/index.js')
     .pipe(webpack(require('./webpack.config.js').minified, require('webpack'))) // pass webpack for webpack2
     .pipe(gulp.dest('./dist/web'));
 });

--- a/src/featureExtractors.js
+++ b/src/featureExtractors.js
@@ -15,16 +15,23 @@ import mfcc from './extractors/mfcc';
 import powerSpectrum from './extractors/powerSpectrum';
 import spectralFlux from './extractors/spectralFlux';
 
-export default {
-  buffer: function (args) {
-    return args.signal;
-  },
+let buffer = function(args) {
+  return args.signal;
+};
 
+let complexSpectrum = function (args) {
+  return args.complexSpectrum;
+};
+
+let amplitudeSpectrum = function (args) {
+  return args.ampSpectrum;
+};
+
+export {
+  buffer,
   rms,
   energy,
-  complexSpectrum: function (args) {
-    return args.complexSpectrum;
-  },
+  complexSpectrum,
 
   spectralSlope,
   spectralCentroid,
@@ -33,9 +40,7 @@ export default {
   spectralSpread,
   spectralSkewness,
   spectralKurtosis,
-  amplitudeSpectrum: function (args) {
-    return args.ampSpectrum;
-  },
+  amplitudeSpectrum,
 
   zcr,
   loudness,
@@ -43,5 +48,5 @@ export default {
   perceptualSharpness,
   powerSpectrum,
   mfcc,
-  spectralFlux,
+  spectralFlux
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./main').default;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
     output: {
      filename: 'meyda.js',
      library: 'Meyda',
-     libraryTarget: 'var'
+     libraryTarget: 'umd'
     },
     module: {
       rules: [
@@ -16,10 +16,7 @@ module.exports = {
           exclude: /node_modules/,
           loader: 'babel-loader',
           options: {
-            presets: ['es2015'],
-            plugins: [
-              'add-module-exports'
-            ]
+            presets: [['es2015', {modules: false}]]
           }
         }
       ]
@@ -31,7 +28,7 @@ module.exports = {
      filename: 'meyda.min.js',
      sourceMapFilename: 'meyda.min.map',
      library: 'Meyda',
-     libraryTarget: 'var'
+     libraryTarget: 'umd'
     },
     module: {
       rules: [
@@ -40,10 +37,7 @@ module.exports = {
           exclude: /node_modules/,
           loader: 'babel-loader',
           options: {
-            presets: ['es2015'],
-            plugins: [
-              'add-module-exports'
-            ]
+            presets: [['es2015', {modules: false}]]
           }
         }
       ]


### PR DESCRIPTION
Allows web dist to be built as UMD (CommonJS, AMD and as global variable), which has greater compatibility over the current `window.Meyda` only solution.

This also allows for meyda's web build to use tree shaking, removing redundant imports and reducing filesize.

This does NOT introduce breaking changes

Completes #203