### PR TITLE
gh-pages use webpack-dev-server (update to webpack 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,13 @@
     "babel-preset-es2015": "^6.6.0",
     "babelify": "^7.3.0",
     "watchify": "^3.7.0",
-    "webpack": "^1.13.0"
+    "webpack": "^2.4.1",
+    "webpack-dev-server": "^2.4.2"
   },
   "scripts": {
     "test": "echo 'No tests yet...'",
     "build": "./node_modules/webpack/bin/webpack.js --progress --color",
-    "serve": "nohup ./node_modules/webpack/bin/webpack.js --progress --color --watch & python -m SimpleHTTPServer"
+    "serve": "./node_modules/.bin/webpack-dev-server --progress --color --open --port 8000 --host 0.0.0.0"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
       {
         test: /\.jsx?$/,
         exclude: /(node_modules|bower_components)/,
-        loader: 'babel', // 'babel-loader' is also a legal name to reference
+        loader: 'babel-loader',
         query: {
           presets: ['es2015']
         }


### PR DESCRIPTION
The serve command assumed python was installed on the user's machine.
Webpack offer a dev server which can serve files and rebuild using webpack at the same time, suggest we use that instead, this required an update to webpack 2.

No breaking changes.